### PR TITLE
Add support for TextEncoder and TextEncoder during testing

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -1,0 +1,4 @@
+// jest.config.js
+module.exports = {
+  setupFiles: ['./test/setupEnv.js']
+}

--- a/test/setupEnv.js
+++ b/test/setupEnv.js
@@ -1,0 +1,8 @@
+if (typeof TextEncoder === 'undefined') {
+  const { TextEncoder } = require('util');
+  global.TextEncoder = TextEncoder;
+}
+if (typeof TextDecoder === 'undefined') {
+  const { TextDecoder } = require('util');
+  global.TextDecoder = TextDecoder;
+}


### PR DESCRIPTION
Jest does not provide TextEncoder or TextEncoder as globals in Node.js during testing. This PR fixes this by adding a custom environment setup script to be run before tests.