### PR TITLE
Update editorconfig to not trim trailing whitespace in markdown files

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -11,3 +11,7 @@ insert_final_newline = true
 [*.yml]
 indent_style = space
 indent_size = 2
+
+[*.md]
+trim_trailing_whitespace = false
+insert_final_newline = true


### PR DESCRIPTION
Trailing whitespaces are stripped I'm Markdown files because of the current editorconfig setup.
This PR adds a specific rule to MD files to not trim trailing whitespaces.